### PR TITLE
Spark7162: DVB-T1 fix

### DIFF
--- a/frontends/spark7162/6158/d6158.c
+++ b/frontends/spark7162/6158/d6158.c
@@ -285,7 +285,7 @@ YW_ErrorType_T demod_d6158earda_ScanFreq(struct dvb_frontend_parameters *p,
 	else if (SYS_DVBT == System)
 	{
 		param.priv_param = DEMO_DVBT;//T2 T
-		param.freq = p->frequency;
+		param.freq = p->frequency / 1000;
 		switch (p->u.ofdm.bandwidth)
 		{
 			case BANDWIDTH_6_MHZ:


### PR DESCRIPTION
This commit partially reverts commit f1903684. It restores the ability to tune and view Irish DVB-T1 channels, and possibly others.